### PR TITLE
Support marking quizzes as illegible and filtering on this state

### DIFF
--- a/src/QuizDetails.tsx
+++ b/src/QuizDetails.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from 'react-router-dom';
 
-import { useQuery } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import { Fragment } from 'preact';
 
 import QuizImageComponent from './QuizImage';
@@ -14,7 +14,8 @@ import {
   formatDateTimeShortTime,
   userIdentifier,
 } from './helpers';
-import { QUIZ } from './queries/quiz';
+import { QUIZ, QUIZZES } from './queries/quiz';
+import { MARK_QUIZ_ILLEGIBLE } from './queries/quiz';
 import { Quiz as QuizType } from './types/quiz';
 
 const imageTypeSortValues: {
@@ -31,6 +32,10 @@ export default function Quiz() {
     quiz: QuizType;
   }>(QUIZ, {
     variables: { id },
+  });
+
+  const [markQuizIllegible, { loading: isMarkingQuizIllegible }] = useMutation(MARK_QUIZ_ILLEGIBLE, {
+    refetchQueries: [{ query: QUIZZES }],
   });
 
   if (loading || data === undefined) return <Loader message='Loading your quiz...' className='mt-10' />;
@@ -64,10 +69,13 @@ export default function Quiz() {
             .map((image) => (
               <QuizImageComponent image={image} className='mt-2' />
             ))}
-          <div>
+          <div className='space-x-2'>
             <Link className='mt-4' to='./enter'>
-              <Button>Record Results</Button>
+              <Button disabled={isMarkingQuizIllegible}>Record Results</Button>
             </Link>
+            <Button onClick={() => markQuizIllegible({ variables: { id } })} disabled={isMarkingQuizIllegible} warning>
+              Mark Quiz Illegible
+            </Button>
           </div>
         </div>
       </div>

--- a/src/QuizDetails.tsx
+++ b/src/QuizDetails.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams } from 'react-router-dom';
+import { Link, useParams, useNavigate } from 'react-router-dom';
 
 import { useMutation, useQuery } from '@apollo/client';
 import { Fragment } from 'preact';
@@ -33,9 +33,12 @@ export default function Quiz() {
   }>(QUIZ, {
     variables: { id },
   });
-
+  const navigate = useNavigate();
   const [markQuizIllegible, { loading: isMarkingQuizIllegible }] = useMutation(MARK_QUIZ_ILLEGIBLE, {
     refetchQueries: [{ query: QUIZZES }],
+    onCompleted: () => {
+      navigate('/');
+    },
   });
 
   if (loading || data === undefined) return <Loader message='Loading your quiz...' className='mt-10' />;

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,5 +1,6 @@
 export interface ButtonProps extends JSX.HTMLAttributes<HTMLButtonElement> {
   danger?: boolean;
+  warning?: boolean;
 }
 
 const disabledClasses =
@@ -7,7 +8,7 @@ const disabledClasses =
 const commonClasses = `inline-flex justify-center py-2 px-4 border border-transparent shadow-sm text-sm font-medium rounded-md text-white ${disabledClasses}`;
 
 export default function Button(props: ButtonProps) {
-  const { danger, className, ...buttonProps } = props;
+  const { danger, warning, className, ...buttonProps } = props;
 
   if (danger) {
     return (
@@ -17,6 +18,16 @@ export default function Button(props: ButtonProps) {
       />
     );
   }
+
+  if (warning) {
+    return (
+      <button
+        className={`${commonClasses} bg-yellow-600 hover:bg-yellow-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500 ${className}`}
+        {...buttonProps}
+      />
+    );
+  }
+
   return (
     <button
       className={`${commonClasses} bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 ${className}`}

--- a/src/hooks/useQuizList.hook.ts
+++ b/src/hooks/useQuizList.hook.ts
@@ -3,10 +3,14 @@ import { useQuery } from '@apollo/client';
 import { useQuizlord } from '../QuizlordProvider';
 import { QUIZZES } from '../queries/quiz';
 
-export function useQuizList(isFilteringOnIncomplete: boolean) {
+export function useQuizList(isFilteringOnIncomplete: boolean, isFilteringOnIllegible: boolean) {
   const { user } = useQuizlord();
+  const filters = {
+    ...(isFilteringOnIncomplete ? { excludeCompletedBy: [user?.email] } : {}),
+    ...(isFilteringOnIllegible ? { excludeIllegible: 'ANYONE' } : {}),
+  };
   const { loading, data, fetchMore, refetch } = useQuery(QUIZZES, {
-    variables: { filters: isFilteringOnIncomplete ? { excludeCompletedBy: [user?.email] } : {} },
+    variables: { filters },
     fetchPolicy: 'network-only',
     notifyOnNetworkStatusChange: true,
   });

--- a/src/pages/list/QuizList.tsx
+++ b/src/pages/list/QuizList.tsx
@@ -36,8 +36,12 @@ interface Node {
 export default function QuizList() {
   const [quizFilters, setQuizFilters] = useState<QuizFilters>({
     isFilteringOnIncomplete: true,
+    isFilteringOnIllegible: true,
   });
-  const { data, loading, fetchMore, refetch } = useQuizList(quizFilters.isFilteringOnIncomplete);
+  const { data, loading, fetchMore, refetch } = useQuizList(
+    quizFilters.isFilteringOnIncomplete,
+    quizFilters.isFilteringOnIllegible,
+  );
   const navigate = useNavigate();
 
   return (

--- a/src/pages/list/QuizListFilters.tsx
+++ b/src/pages/list/QuizListFilters.tsx
@@ -11,18 +11,39 @@ export interface QuizListFiltersProps {
 
 export function QuizListFilters({ filters, onFiltersChanged, className }: QuizListFiltersProps) {
   return (
-    <div
-      className={`cursor-pointer${className ? ` ${className}` : ''}`}
-      onClick={() => onFiltersChanged({ isFilteringOnIncomplete: !filters.isFilteringOnIncomplete })}
-    >
-      <FontAwesomeIcon
-        icon={filters.isFilteringOnIncomplete ? faFilter : faFilterCircleXmark}
-        size='xl'
-        className='text-gray-800'
-      />
-      <span className='ml-4'>
-        {filters.isFilteringOnIncomplete ? 'Showing only incomplete quizzes' : 'Showing all quizzes'}
-      </span>
-    </div>
+    <>
+      <div
+        className={`cursor-pointer${className ? ` ${className}` : ''}`}
+        onClick={() =>
+          onFiltersChanged({
+            ...filters,
+            isFilteringOnIncomplete: !filters.isFilteringOnIncomplete,
+          })
+        }
+      >
+        <FontAwesomeIcon
+          icon={filters.isFilteringOnIncomplete ? faFilter : faFilterCircleXmark}
+          size='xl'
+          className='text-gray-800'
+        />
+        <span className='ml-4'>{filters.isFilteringOnIncomplete ? 'Incomplete Only' : 'No Incomplete Filter'}</span>
+      </div>
+      <div
+        className={`cursor-pointer${className ? ` ${className}` : ''}`}
+        onClick={() =>
+          onFiltersChanged({
+            ...filters,
+            isFilteringOnIllegible: !filters.isFilteringOnIllegible,
+          })
+        }
+      >
+        <FontAwesomeIcon
+          icon={filters.isFilteringOnIllegible ? faFilter : faFilterCircleXmark}
+          size='xl'
+          className='text-gray-800'
+        />
+        <span className='ml-4'>{filters.isFilteringOnIllegible ? 'Readable Only' : 'No Readability Filter'}</span>
+      </div>
+    </>
   );
 }

--- a/src/pages/list/quizFilters.ts
+++ b/src/pages/list/quizFilters.ts
@@ -1,3 +1,4 @@
 export interface QuizFilters {
   isFilteringOnIncomplete: boolean;
+  isFilteringOnIllegible: boolean;
 }

--- a/src/queries/quiz.ts
+++ b/src/queries/quiz.ts
@@ -127,3 +127,9 @@ export const CREATE_QUIZ = gql`
     }
   }
 `;
+
+export const MARK_QUIZ_ILLEGIBLE = gql`
+  mutation MarkQuizIllegible($id: String!) {
+    markQuizIllegible(quizId: $id)
+  }
+`;


### PR DESCRIPTION
Works off the api ticket https://github.com/danielemery/quizlord-api/issues/46

- Adds a new button on the quiz summary page that allows users to mark quizzes as illegible.
- Adds a new filter at the top of the main quiz list that allows toggling filtering on this new marker
- Note although the api supports the `ANYONE` or `ME` option for this filter to get something out fast we're just using `ANYONE` for now
- Adds support for a new button type: `warning`
- Makes the language more concise on the filters now that two need to fit