### PR TITLE
Use local storage for auth0 session

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -16,6 +16,7 @@ render(
       audience: window.env.VITE_AUTH0_AUDIENCE,
       redirect_uri: window.location.origin,
     }}
+    cacheLocation='localstorage'
   >
     <BrowserRouter>
       <AuthorizedApolloProvider>


### PR DESCRIPTION
Store the auth session in local storage rather than memory.

Note this is considered not best practice, but since Quizlord does not store any sensitive data is's considered acceptable for this project.
If a better solution comes along, we will migrate to it.

This partially addresses #53 but the other suggestions in that issue should also be implemented before it's considered complete.
