### PR TITLE
Inline the node versions in Github actions to test if renovate can include them in it's upgrade PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,6 @@ permissions:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
-  NODE_VERSION: 22.10.0
 
 jobs:
   build:
@@ -30,7 +29,7 @@ jobs:
       - name: Configure node
         uses: actions/setup-node@v4.1.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 22.10.0
 
       - name: Install packages
         run: npm ci

--- a/.github/workflows/validate-pr.yaml
+++ b/.github/workflows/validate-pr.yaml
@@ -8,9 +8,6 @@ on:
 permissions:
   contents: read
 
-env:
-  NODE_VERSION: 22.10.0
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -21,7 +18,7 @@ jobs:
       - name: Configure node
         uses: actions/setup-node@v4.1.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 22.10.0
 
       - name: Install packages
         run: npm ci
@@ -48,7 +45,7 @@ jobs:
       - name: Configure node
         uses: actions/setup-node@v4.1.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: 22.10.0
 
       - name: Install packages
         run: npm ci


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified Node.js version configuration by hardcoding the version to `22.10.0` in workflow files.
	- Removed the `NODE_VERSION` environment variable from the workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->