### PR TITLE
Hide individual entry button when questions don't exist

### DIFF
--- a/src/EnterQuizResults.tsx
+++ b/src/EnterQuizResults.tsx
@@ -107,9 +107,11 @@ export default function EnterQuizResults() {
                       onChange={(e) => setManuallyEnteredTotalScore(parseFloat((e.target as HTMLInputElement).value))}
                       className='shadow-sm focus:ring-indigo-500 focus:border-indigo-500 mt-1 block w-full sm:text-sm border border-gray-300 rounded-md'
                     />
-                    <Link to={`/quiz/${id}/question/1`}>
-                      <Button>Individual Entry</Button>
-                    </Link>
+                    {(data.quiz.questions?.length ?? 0) > 0 && (
+                      <Link to={`/quiz/${id}/question/1`}>
+                        <Button>Individual Entry</Button>
+                      </Link>
+                    )}
                   </div>
                 )}
               </div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The "Individual Entry" button is now only shown if the quiz contains at least one question, preventing display of the button for empty quizzes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->