### PR TITLE
Persist quiz list filters in local storage (indexedDB)

### DIFF
--- a/src/hooks/useQuizFilters.ts
+++ b/src/hooks/useQuizFilters.ts
@@ -1,0 +1,92 @@
+import { liveQuery } from 'dexie';
+import { useEffect, useState } from 'preact/hooks';
+
+import { db } from '../services/db';
+
+const EXCLUDED_USER_EMAILS_KEY = 'QUIZ_FILTER_EXCLUDED_USER_EMAILS';
+const IS_FILTERING_ON_ILLEGIBLE_KEY = 'QUIZ_FILTER_IS_FILTERING_ON_ILLEGIBLE';
+
+export interface QuizFilters {
+  excludedUserEmails: string[];
+  isFilteringOnIllegible: boolean;
+}
+
+const DEFAULT_FILTERS: QuizFilters = {
+  excludedUserEmails: [],
+  isFilteringOnIllegible: true,
+};
+
+export function useQuizFilters(authenticatedUserEmail?: string | null) {
+  // Default filter excludes quizzes completed by the authenticated user
+  const initialFilters: QuizFilters = {
+    ...DEFAULT_FILTERS,
+    excludedUserEmails: authenticatedUserEmail ? [authenticatedUserEmail] : [],
+  };
+
+  const [filters, setFilters] = useState<QuizFilters | undefined>(undefined);
+
+  const settings$ = liveQuery(() => db.settings.toArray());
+
+  useEffect(() => {
+    const subscription = settings$.subscribe(async (settings) => {
+      const excludedUserEmailsSetting = settings.find((setting) => setting.name === EXCLUDED_USER_EMAILS_KEY);
+      let excludedUserEmails = initialFilters.excludedUserEmails;
+
+      if (excludedUserEmailsSetting) {
+        try {
+          excludedUserEmails = JSON.parse(excludedUserEmailsSetting.value);
+        } catch (e) {
+          console.error('Failed to parse excluded user emails', e);
+        }
+      } else {
+        await db.settings.add({
+          name: EXCLUDED_USER_EMAILS_KEY,
+          value: JSON.stringify(initialFilters.excludedUserEmails),
+        });
+      }
+
+      const isFilteringOnIllegibleSetting = settings.find((setting) => setting.name === IS_FILTERING_ON_ILLEGIBLE_KEY);
+      let isFilteringOnIllegible = initialFilters.isFilteringOnIllegible;
+
+      if (isFilteringOnIllegibleSetting) {
+        isFilteringOnIllegible = isFilteringOnIllegibleSetting.value === 'true';
+      } else {
+        await db.settings.add({
+          name: IS_FILTERING_ON_ILLEGIBLE_KEY,
+          value: String(initialFilters.isFilteringOnIllegible),
+        });
+      }
+
+      setFilters({
+        excludedUserEmails,
+        isFilteringOnIllegible,
+      });
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [settings$, initialFilters]);
+
+  const updateFilters = async (changes: Partial<QuizFilters>) => {
+    if (changes.excludedUserEmails !== undefined) {
+      await db.settings.put({
+        name: EXCLUDED_USER_EMAILS_KEY,
+        value: JSON.stringify(changes.excludedUserEmails),
+      });
+    }
+
+    if (changes.isFilteringOnIllegible !== undefined) {
+      await db.settings.put({
+        name: IS_FILTERING_ON_ILLEGIBLE_KEY,
+        value: String(changes.isFilteringOnIllegible),
+      });
+    }
+  };
+
+  return {
+    filters: filters ?? initialFilters,
+    updateFilters,
+    loading: filters === undefined,
+  };
+}

--- a/src/pages/list/QuizList.tsx
+++ b/src/pages/list/QuizList.tsx
@@ -1,7 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
 import { Fragment } from 'preact';
-import { useState } from 'preact/hooks';
 
 import { useQuizlord } from '../../QuizlordProvider';
 import Button from '../../components/Button';
@@ -14,10 +13,10 @@ import {
   formatDateTimeShortTime,
   userIdentifier,
 } from '../../helpers';
+import { useQuizFilters } from '../../hooks/useQuizFilters';
 import { useQuizList } from '../../hooks/useQuizList.hook';
 import { User } from '../../types/user';
 import { QuizListControls } from './QuizListControls';
-import { QuizFilters } from './quizFilters';
 
 interface QuizCompletion {
   completedAt: string;
@@ -34,61 +33,42 @@ interface Node {
 
 export default function QuizList() {
   const { user: authenticatedUser } = useQuizlord();
-  const [quizFilters, setQuizFilters] = useState<QuizFilters>({
-    excludedUserEmails: authenticatedUser?.email ? [authenticatedUser?.email] : [],
-    isFilteringOnIllegible: true,
-  });
-  const { data, loading, fetchMore, refetch } = useQuizList(
-    quizFilters.excludedUserEmails,
-    quizFilters.isFilteringOnIllegible,
-  );
+  const { filters, updateFilters, loading: filtersLoading } = useQuizFilters(authenticatedUser?.email);
+
+  const { data, loading, fetchMore, refetch } = useQuizList(filters.excludedUserEmails, filters.isFilteringOnIllegible);
   const navigate = useNavigate();
 
   return (
     <>
       <QuizListControls
         className='flex-1'
-        filters={quizFilters}
-        onFiltersChanged={(changes) =>
-          setQuizFilters((prevState) => ({
-            ...prevState,
-            ...changes,
-          }))
-        }
+        filters={filters}
+        onFiltersChanged={(changes) => updateFilters(changes)}
         onRefreshClicked={() => refetch()}
       />
-      <div>
-        <Table className='table-fixed'>
-          <Table.Head>
-            <Table.Row className='hidden lg:table-row' isHeader>
-              <Table.HeaderCell>Quiz Date</Table.HeaderCell>
-              <Table.HeaderCell>Type</Table.HeaderCell>
-              <Table.HeaderCell>Uploaded By</Table.HeaderCell>
-              <Table.HeaderCell>Completed</Table.HeaderCell>
-              <Table.HeaderCell>Result</Table.HeaderCell>
-            </Table.Row>
-            <Table.Row className='lg:hidden' isHeader>
-              <Table.HeaderCell>Quiz Details</Table.HeaderCell>
-              <Table.HeaderCell>Completion</Table.HeaderCell>
-            </Table.Row>
-          </Table.Head>
-          <Table.Body>
-            {loading && (
-              <>
-                <Table.Row className='hidden lg:table-row'>
-                  <Table.Cell colSpan={5}>
-                    <Loader message='Loading available quizzes...' />
-                  </Table.Cell>
-                </Table.Row>
-                <Table.Row className='lg:hidden'>
-                  <Table.Cell colSpan={2}>
-                    <Loader message='Loading available quizzes...' />
-                  </Table.Cell>
-                </Table.Row>
-              </>
-            )}
-            {!loading &&
-              data.quizzes.edges.map(({ node }: { node: Node }) => (
+      {(loading || filtersLoading) && (
+        <div className='flex justify-center my-4'>
+          <Loader message='Loading...' />
+        </div>
+      )}
+      {!loading && !filtersLoading && (
+        <div>
+          <Table className='table-fixed'>
+            <Table.Head>
+              <Table.Row className='hidden lg:table-row' isHeader>
+                <Table.HeaderCell>Quiz Date</Table.HeaderCell>
+                <Table.HeaderCell>Type</Table.HeaderCell>
+                <Table.HeaderCell>Uploaded By</Table.HeaderCell>
+                <Table.HeaderCell>Completed</Table.HeaderCell>
+                <Table.HeaderCell>Result</Table.HeaderCell>
+              </Table.Row>
+              <Table.Row className='lg:hidden' isHeader>
+                <Table.HeaderCell>Quiz Details</Table.HeaderCell>
+                <Table.HeaderCell>Completion</Table.HeaderCell>
+              </Table.Row>
+            </Table.Head>
+            <Table.Body>
+              {data.quizzes.edges.map(({ node }: { node: Node }) => (
                 <Fragment key={node.id}>
                   <Table.Row className='hidden lg:table-row' isHoverable onClick={() => navigate(`/quiz/${node.id}`)}>
                     <Table.Cell>{formatDate(node.date)}</Table.Cell>
@@ -119,9 +99,10 @@ export default function QuizList() {
                   </Table.Row>
                 </Fragment>
               ))}
-          </Table.Body>
-        </Table>
-      </div>
+            </Table.Body>
+          </Table>
+        </div>
+      )}
       {data?.quizzes?.pageInfo?.hasNextPage && (
         <div className='flex justify-center items-center mt-4'>
           <Button onClick={() => fetchMore({ variables: { after: data.quizzes.pageInfo.endCursor } })}>

--- a/src/pages/list/QuizListControls.tsx
+++ b/src/pages/list/QuizListControls.tsx
@@ -5,12 +5,12 @@ import { useState } from 'preact/hooks';
 import { useQuizlord } from '../../QuizlordProvider';
 import Button from '../../components/Button';
 import { userIdentifier } from '../../helpers';
+import { QuizFilters } from '../../hooks/useQuizFilters';
 import { UserSelectorWithLoader } from './UserSelectorWithLoader';
-import { QuizFilters } from './quizFilters';
 
 export interface QuizListControlsProps {
   filters: QuizFilters;
-  onFiltersChanged: (filterChanges: QuizFilters) => void;
+  onFiltersChanged: (filterChanges: Partial<QuizFilters>) => void;
   onRefreshClicked: () => void;
   className?: string;
 }
@@ -37,7 +37,6 @@ export function QuizListControls({ filters, onFiltersChanged, onRefreshClicked, 
           className={`cursor-pointer${className ? ` ${className}` : ''}`}
           onClick={() =>
             onFiltersChanged({
-              ...filters,
               isFilteringOnIllegible: !filters.isFilteringOnIllegible,
             })
           }
@@ -74,7 +73,6 @@ export function QuizListControls({ filters, onFiltersChanged, onRefreshClicked, 
             <Button
               onClick={() => {
                 onFiltersChanged({
-                  ...filters,
                   excludedUserEmails: [...pendingSelections, ...(authenticatedUser ? [authenticatedUser.email] : [])],
                 });
                 setIsSelectingUsers(false);
@@ -86,7 +84,6 @@ export function QuizListControls({ filters, onFiltersChanged, onRefreshClicked, 
               warning
               onClick={() => {
                 onFiltersChanged({
-                  ...filters,
                   excludedUserEmails: [],
                 });
                 setIsSelectingUsers(false);

--- a/src/pages/list/quizFilters.ts
+++ b/src/pages/list/quizFilters.ts
@@ -1,4 +1,0 @@
-export interface QuizFilters {
-  excludedUserEmails: string[];
-  isFilteringOnIllegible: boolean;
-}


### PR DESCRIPTION
- **Persist quiz list filters in IndexedDB using settings table**
- **Clear filter settings when user changes within the same browser session**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Quiz filter preferences are now saved and loaded automatically, allowing personalized filtering based on user settings.
- **Refactor**
  - Centralized quiz filter management into a dedicated system, streamlining filter updates and loading states across the quiz list.
- **Style**
  - Improved loading experience with a unified and simplified loading indicator for quiz data and filter settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->