### PR TITLE
Mirrored quizlord-api dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Renovate owns version updates for this repo; Dependabot is kept only for security updates.
+# `open-pull-requests-limit: 0` disables Dependabot version-update PRs (so it does not duplicate
+# Renovate) while security-update PRs continue to be raised and pick up the `semver:patch` label
+# required by the validate-pr label gate.
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 0
+    labels:
+      - "semver:patch"

--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,16 @@
   "extends": [
     "config:recommended",
     ":prConcurrentLimitNone"
+  ],
+  "labels": ["semver:patch"],
+  "packageRules": [
+    {
+      "description": "Auto-merge patch and minor updates after a 7-day soak; major updates stay manual. platformAutomerge uses GitHub's native auto-merge, so each PR merges only once the required branch-protection checks pass and only Renovate's own PRs are affected. automergeStrategy is pinned to 'merge' because the main ruleset only permits merge commits; GitHub rejects arming auto-merge if Renovate requests a disallowed strategy.",
+      "matchUpdateTypes": ["patch", "minor"],
+      "minimumReleaseAge": "7 days",
+      "automerge": true,
+      "platformAutomerge": true,
+      "automergeStrategy": "merge"
+    }
   ]
 }


### PR DESCRIPTION
Added Renovate auto-merge for patch and minor updates after a 7-day
soak (platformAutomerge with automergeStrategy pinned to merge to match
the main ruleset's merge-only policy) and the semver:patch label so
Renovate PRs pass the validate-pr label gate.

Added a Dependabot config that disables version-update PRs
(open-pull-requests-limit 0) so it does not duplicate Renovate, while
security updates continue and pick up the semver:patch label.

The matching repo merge settings and main branch ruleset were applied
directly on GitHub to align with quizlord-api.

Co-Authored-By: Claude <noreply@anthropic.com>
