### PR TITLE
Restored v prefix on published docker images

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -34,7 +34,6 @@ jobs:
     outputs:
       version: ${{ steps.calc.outputs.version }}
       tag: ${{ steps.calc.outputs.tag }}
-      base-version: ${{ steps.calc.outputs.base-version }}
     steps:
       - name: Calculate prerelease version
         id: calc
@@ -107,11 +106,15 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.version }}
+          # Tag with the v-prefixed version (e.g. v1.2.3-rc.2) so the image tag matches what the helm
+          # chart references via .Values.client.version. The bare `version` output is only used where a
+          # strict-semver string is required (the helm chart version/appVersion below).
+          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.version.outputs.tag }}
           # Baked fallback only — helm injects the accurate per-env version at runtime
-          # (VITE_QUIZLORD_VERSION), so this is what `docker run` shows without helm.
+          # (VITE_QUIZLORD_VERSION), so this is what `docker run` shows without helm. Uses the full
+          # v-prefixed tag (e.g. v1.2.3-rc.2) to match the github release and image tag.
           build-args: |
-            IMAGE_VERSION=${{ needs.version.outputs.base-version }}
+            IMAGE_VERSION=${{ needs.version.outputs.tag }}
 
   helm-publish:
     needs:

--- a/.github/workflows/release-stable.yml
+++ b/.github/workflows/release-stable.yml
@@ -57,18 +57,18 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Retag the immutable rc image to the stable version (no rebuild). The rc image was pushed under
-      # its bare version (e.g. 1.2.3-rc.2); strip the leading `v` from the supplied tag to match.
-      # `latest` is deferred to retag-latest so it only moves once all artifacts have promoted.
+      # Retag the immutable rc image to the stable version (no rebuild). Both images carry the
+      # v-prefixed version (e.g. v1.2.3-rc.2 -> v1.2.3) so the tags match what the helm chart references
+      # via .Values.client.version. `latest` is deferred to retag-latest so it only moves once all
+      # artifacts have promoted.
       - name: Retag rc image as stable
         env:
           RC_TAG: ${{ inputs.prerelease_version }}
-          STABLE: ${{ needs.pre_release.outputs.release-version }}
+          STABLE: ${{ needs.pre_release.outputs.release-tag }}
         run: |
-          RC="${RC_TAG#v}"
           docker buildx imagetools create \
             --tag "${REGISTRY}/${IMAGE_NAME}:${STABLE}" \
-            "${REGISTRY}/${IMAGE_NAME}:${RC}"
+            "${REGISTRY}/${IMAGE_NAME}:${RC_TAG}"
 
   helm-stable:
     needs: pre_release
@@ -115,7 +115,7 @@ jobs:
       # tag is never left pointing at an incompletely promoted release.
       - name: Point latest at the stable image
         env:
-          STABLE: ${{ needs.pre_release.outputs.release-version }}
+          STABLE: ${{ needs.pre_release.outputs.release-tag }}
         run: |
           docker buildx imagetools create \
             --tag "${REGISTRY}/${IMAGE_NAME}:latest" \


### PR DESCRIPTION
The versioning rework pushed docker images under their bare version
(1.2.3), but the helm chart references images with a v prefix via
.Values.client.version, so deploys pointed at non-existent tags.

Tag and retag rc/stable/latest images with the v-prefixed version,
and bake the full v-prefixed tag into IMAGE_VERSION to match the
github release. The helm chart version/appVersion stay plain semver
as required by the chart repo.

Co-Authored-By: Claude <noreply@anthropic.com>
