### PR TITLE
Renovate docker-react version sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,23 @@ jobs:
 
       - name: Lint
         run: npm run lint
+
+  # Asserts the client's zod pin exactly matches docker-react's
+  # peerDependencies.zod. Renovate is configured to skip zod
+  # (see renovate.json) so this guards against manual drift and
+  # against docker-react bumps that change the peer constraint.
+  zod-peer-dep-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Assert zod matches docker-react peer dependency
+        run: |
+          client_zod=$(jq -r '.dependencies.zod' package.json)
+          dr_peer_zod=$(jq -r '.packages["node_modules/docker-react"].peerDependencies.zod' package-lock.json)
+          if [ "$client_zod" != "$dr_peer_zod" ]; then
+            echo "::error::client zod ($client_zod) does not match docker-react peerDependencies.zod ($dr_peer_zod). Bump zod in package.json to $dr_peer_zod and re-run npm install."
+            exit 1
+          fi
+          echo "zod $client_zod matches docker-react peer dep"

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "react-router-dom": "^7.13.0",
         "rxjs": "^7.8.2",
         "uuid": "^14.0.0",
-        "zod": "^4.4.3",
+        "zod": "4.4.3",
         "zustand": "^5.0.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-router-dom": "^7.13.0",
     "rxjs": "^7.8.2",
     "uuid": "^14.0.0",
-    "zod": "^4.4.3",
+    "zod": "4.4.3",
     "zustand": "^5.0.1"
   },
   "devDependencies": {

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,11 @@
       "description": "docker-react ships as both an npm CLI (used by `init-local`) and a Docker base image (used by the Dockerfile). The two are released in lockstep and must always match, so renovate updates them as a single grouped PR.",
       "matchPackageNames": ["docker-react", "demery/docker-react"],
       "groupName": "docker-react"
+    },
+    {
+      "description": "zod is held to an exact pin that must match docker-react's peerDependencies.zod. The zod-peer-dep-guard CI job enforces the match. Renovate is disabled for zod here so it cannot raise a PR that would break the peer constraint; zod bumps come in through the docker-react grouped PR instead.",
+      "matchPackageNames": ["zod"],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -13,6 +13,11 @@
       "automerge": true,
       "platformAutomerge": true,
       "automergeStrategy": "merge"
+    },
+    {
+      "description": "docker-react ships as both an npm CLI (used by `init-local`) and a Docker base image (used by the Dockerfile). The two are released in lockstep and must always match, so renovate updates them as a single grouped PR.",
+      "matchPackageNames": ["docker-react", "demery/docker-react"],
+      "groupName": "docker-react"
     }
   ]
 }


### PR DESCRIPTION
- **Grouped docker-react npm and Docker updates**
- **Pinned zod to exact 4.4.3 to match docker-react**
- **Disabled renovate for zod and added CI peer-dep guard**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a validation check to prevent incompatible `zod` updates from being merged, helping keep dependency versions in sync.
  * Locked `zod` to an exact version to avoid unexpected version drift.

* **Chores**
  * Improved automated dependency update handling so related `docker-react` updates are grouped together, while `zod` updates are blocked from separate rollout paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->